### PR TITLE
Add an opam file

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -34,7 +34,7 @@ Flag benchmarks
 # +-------------------------------------------------------------------+
 
 Library stream_s
-  Findlibname:      stream_s
+  Findlibname:      staged-streams
   Path:             lib
   BuildTools:       ocamlbuild
   InternalModules:  Stream_constructors, Stream_combinators
@@ -49,7 +49,7 @@ Executable run_benchmarks
   MainIs:           benchmark_stream.ml
   Build$:           flag(benchmarks)
   Install:          false
-  BuildDepends:     oml, stream_s
+  BuildDepends:     oml, staged-streams
 
 Executable run_batteries_benchmarks
   Path:             benchmarks
@@ -63,7 +63,7 @@ Executable test_stream
   MainIs:           test_stream.ml
   Build$:           flag(tests)
   Install:          false
-  BuildDepends:     stream_s, oUnit
+  BuildDepends:     staged-streams, oUnit
 
 Test stream
   Command: $test_stream

--- a/opam
+++ b/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+name: "staged-streams"
+version: "dev"
+authors: [
+  "Oleg Kiselyov"
+  "Aggelos Biboudis"
+  "Nick Palladinos"
+  "Yannis Smaragdakis"
+]
+maintainer: "oleg@okmij.org"
+homepage: "https://strymonas.github.io/"
+dev-repo: "https://github.com/strymonas/staged-streams.ocaml.git"
+bug-reports: "https://github.com/strymonas/staged-streams.ocaml/issues"
+build: [
+  ["./configure" "--prefix" "%{prefix}%"]
+  [make "all"]
+]
+install:[make "install"]
+remove: ["ocamlfind" "remove" "staged-streams"]
+depends: [
+   "batteries" {= "2.3.0"}
+   "oml"
+   "ocamlfind" {build}
+   "oasis" {build}
+]
+available: [ (compiler = "4.02.1+BER")
+           | (compiler = "4.02.1+modular-implicits-ber") ]


### PR DESCRIPTION
This makes it easier to install the package.  With this change, the last few steps of the installation instructions can be replaced by:

```
opam pin add staged-streams http://github.com/strymonas/staged-streams.ocaml.git
```

The `opam` file can also be used to submit the package to [opam-repository](https://github.com/ocaml/opam-repository/).