### PR TITLE
Support other MetaOCaml compilers (including 4.04.0 / n104)

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -12,10 +12,6 @@ License: MIT
 Plugins:
    META (0.4),
    DevFiles (0.4)
-BuildDepends:
-   oUnit (>= 2.0),
-   batteries (= 2.3),
-   oml
 
 # +-------------------------------------------------------------------+
 # | Flags                                                             |
@@ -56,7 +52,7 @@ Executable run_batteries_benchmarks
   MainIs:           benchmark_batteries.ml
   Build$:           flag(benchmarks)
   Install:          false
-  BuildDepends:     batteries
+  BuildDepends:     batteries (= 2.3)
 
 Executable test_stream
   Path:             test

--- a/opam
+++ b/opam
@@ -18,7 +18,7 @@ build: [
 install:[make "install"]
 remove: ["ocamlfind" "remove" "staged-streams"]
 depends: [
-   "batteries" {= "2.3.0"}
+   "batteries" {test & = "2.3.0"}
    "oml" {build}
    "ocamlfind" {build}
    "oasis" {build}

--- a/opam
+++ b/opam
@@ -23,5 +23,5 @@ depends: [
    "ocamlfind" {build}
    "oasis" {build}
    "ounit" {build}
+   "base-metaocaml-ocamlfind"
 ]
-available: [ (compiler = "4.02.1+BER") ]


### PR DESCRIPTION
This fixes #7.

There are two changes:
* 84a901a removes the compiler availability constraint, replacing it with a dependency on the [`base-metaocaml-ocamlfind`package](https://opam.ocaml.org/packages/base-metaocaml-ocamlfind/), which is available for all MetaOCaml-based compilers (and only for those compilers).  In other words, depending on `base-metaocaml-ocamlfind` is a way of restricting availability to the various MetaOCaml-based compilers without actually enumerating them.

* 378c1c8 makes `batteries` a test-only dependency in opam (which means it currently won't be installed when pinning the package, since the `opam` file doesn't have a test section), and a local rather than a global dependency in `_oasis` (which means that it'll be required only when the `benchmarks` flag is enabled).
  The reason for updating the batteries dependencies is that the batteries version is currently constrained to [`2.3.0`](https://opam.ocaml.org/packages/batteries/batteries.2.3.0/), which isn't available for the 4.04.0 compiler.